### PR TITLE
Trim line before parsing it

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -19,6 +19,7 @@ export class MessageParser {
         let results = [];
         let lines = data.split('\n');
         for (let line of lines) {
+            line = line.trim();
             let found = line.match(genericRegexp);
             if (found) {
                 results.push({

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -17,9 +17,8 @@ export class MessageParser {
 
     parseLines(data) {
         let results = [];
-        let lines = data.split('\n');
+        let lines = data.split(/(\r|\n|\r\n)/).filter(function(line) { return !!line.trim(); });
         for (let line of lines) {
-            line = line.trim();
             let found = line.match(genericRegexp);
             if (found) {
                 results.push({


### PR DESCRIPTION
  * When pylama is run on platforms where LF is not EOL, allows to correctly match the line anyway
  * Closes #36 